### PR TITLE
Save package build output to its own versioned directory

### DIFF
--- a/.github/workflows/subflow-build-packages.yml
+++ b/.github/workflows/subflow-build-packages.yml
@@ -48,6 +48,7 @@ jobs:
             --version=${{ matrix.full_version }} \
             --suffix=${{ matrix.suffix }} \
             --architecture=amd64 \
+            --output-path=assets/packages \
             2>&1 | tee build-package.amd64.log
 
       - name: Build arm64 packages
@@ -57,6 +58,7 @@ jobs:
             --version=${{ matrix.full_version }} \
             --suffix=${{ matrix.suffix }} \
             --architecture=arm64 \
+            --output-path=assets/packages \
             2>&1 | tee build-package.arm64.log
 
       - name: Save files to build

--- a/cmd/build_packages/build.go
+++ b/cmd/build_packages/build.go
@@ -52,8 +52,8 @@ func buildOutput(buildParameters *build.BuildParameters, ctx context.Context, cl
 
 	// Prepare package
 	container, err = container.
-		WithExec([]string{"cp", "/home/build/source/" + sourceArchiveFileName, "/home/build/packages/" + sourceArchiveFileName}).
-		WithExec([]string{"tar", "-xzf", "/home/build/packages/" + sourceArchiveFileName, "--strip-components=1", "--exclude", "debian"}).
+		WithExec([]string{"cp", "/home/build/source/" + sourceArchiveFileName, buildParameters.BuildDirectoryRootPath + "/" + sourceArchiveFileName}).
+		WithExec([]string{"tar", "-xzf", buildParameters.BuildDirectoryRootPath + "/" + sourceArchiveFileName, "--strip-components=1", "--exclude", "debian"}).
 		WithExec([]string{"cp", "-R", "/home/build/source/" + buildParameters.ShortVersion, buildParameters.BuildDirectoryPath + "/debian"}).
 		WithExec([]string{"rm", "-f", "debian/changelog"}).
 		WithExec([]string{"debchange", "--create", "--package", buildParameters.PackageName, "--distribution", "stable", "-v", buildParameters.Version + "-" + strconv.Itoa(buildParameters.BuildNumber), buildParameters.Version + "-" + strconv.Itoa(buildParameters.BuildNumber) + " automated build"}).


### PR DESCRIPTION
Save package build output to its own versioned directory to avoid mixing build output for different PHP versions.