### PR TITLE
Remove dependency on php-common Debian package to v7 builds

### DIFF
--- a/assets/source/5.6/control.in
+++ b/assets/source/5.6/control.in
@@ -1,9 +1,8 @@
 Source: php@PHP_VERSION@
 Section: php
 Priority: optional
-Maintainer: Debian PHP Maintainers <team+pkg-php@tracker.debian.org>
-Uploaders: Ondřej Surý <ondrej@debian.org>,
-           Lior Kaplan <kaplan@debian.org>
+Maintainer: Simon Paulger <spaulger@codezen.co.uk>
+Uploaders: Simon Paulger <spaulger@codezen.co.uk>
 Build-Depends: apache2-dev (>= 2.4),
                autoconf (>= 2.63),
                automake,

--- a/assets/source/5.6/php-module.control.in
+++ b/assets/source/5.6/php-module.control.in
@@ -1,10 +1,9 @@
 Package: @package@
 Architecture: any
-Depends: php-common (>= 1:81~),
-         ucf,
+Depends: ucf,
          ${misc:Depends},
          ${php:Depends},
-	 ${php-@ext@:Depends},
+	     ${php-@ext@:Depends},
          ${shlibs:Depends}
 Pre-Depends: ${misc:Pre-Depends},
 	     ${php-@ext@:Pre-Depends}

--- a/assets/source/7.0/control.in
+++ b/assets/source/7.0/control.in
@@ -1,9 +1,8 @@
 Source: php@PHP_VERSION@
 Section: php
 Priority: optional
-Maintainer: Debian PHP Maintainers <team+pkg-php@tracker.debian.org>
-Uploaders: Ondřej Surý <ondrej@debian.org>,
-           Lior Kaplan <kaplan@debian.org>
+Maintainer: Simon Paulger <spaulger@codezen.co.uk>
+Uploaders: Simon Paulger <spaulger@codezen.co.uk>
 Build-Depends: apache2-dev (>= 2.4),
                autoconf (>= 2.63),
                automake,

--- a/assets/source/7.0/php-module.control.in
+++ b/assets/source/7.0/php-module.control.in
@@ -1,10 +1,9 @@
 Package: @package@
 Architecture: any
-Depends: php-common (>= 1:81~),
-         ucf,
+Depends: ucf,
          ${misc:Depends},
          ${php:Depends},
-	 ${php-@ext@:Depends},
+	     ${php-@ext@:Depends},
          ${shlibs:Depends}
 Pre-Depends: ${misc:Pre-Depends},
 	     ${php-@ext@:Pre-Depends}

--- a/assets/source/7.1/control.in
+++ b/assets/source/7.1/control.in
@@ -1,9 +1,8 @@
 Source: php@PHP_VERSION@
 Section: php
 Priority: optional
-Maintainer: Debian PHP Maintainers <team+pkg-php@tracker.debian.org>
-Uploaders: Ondřej Surý <ondrej@debian.org>,
-           Lior Kaplan <kaplan@debian.org>
+Maintainer: Simon Paulger <spaulger@codezen.co.uk>
+Uploaders: Simon Paulger <spaulger@codezen.co.uk>
 Build-Depends: apache2-dev (>= 2.4),
                autoconf (>= 2.63),
                automake,

--- a/assets/source/7.1/php-module.control.in
+++ b/assets/source/7.1/php-module.control.in
@@ -1,10 +1,9 @@
 Package: @package@
 Architecture: any
-Depends: php-common (>= 1:81~),
-         ucf,
+Depends: ucf,
          ${misc:Depends},
          ${php:Depends},
-	 ${php-@ext@:Depends},
+	     ${php-@ext@:Depends},
          ${shlibs:Depends}
 Pre-Depends: ${misc:Pre-Depends},
 	     ${php-@ext@:Pre-Depends}

--- a/assets/source/7.2/control.in
+++ b/assets/source/7.2/control.in
@@ -1,9 +1,8 @@
 Source: php@PHP_VERSION@
 Section: php
 Priority: optional
-Maintainer: Debian PHP Maintainers <team+pkg-php@tracker.debian.org>
-Uploaders: Ondřej Surý <ondrej@debian.org>,
-           Lior Kaplan <kaplan@debian.org>
+Maintainer: Simon Paulger <spaulger@codezen.co.uk>
+Uploaders: Simon Paulger <spaulger@codezen.co.uk>
 Build-Depends: apache2-dev (>= 2.4),
                autoconf (>= 2.63),
                automake,

--- a/assets/source/7.2/php-module.control.in
+++ b/assets/source/7.2/php-module.control.in
@@ -1,10 +1,9 @@
 Package: @package@
 Architecture: any
-Depends: php-common (>= 1:81~),
-         ucf,
+Depends: ucf,
          ${misc:Depends},
          ${php:Depends},
-	 ${php-@ext@:Depends},
+	     ${php-@ext@:Depends},
          ${shlibs:Depends}
 Pre-Depends: ${misc:Pre-Depends},
 	     ${php-@ext@:Pre-Depends}

--- a/assets/source/7.3/control.in
+++ b/assets/source/7.3/control.in
@@ -1,9 +1,8 @@
 Source: php@PHP_VERSION@
 Section: php
 Priority: optional
-Maintainer: Debian PHP Maintainers <team+pkg-php@tracker.debian.org>
-Uploaders: Ondřej Surý <ondrej@debian.org>,
-           Lior Kaplan <kaplan@debian.org>
+Maintainer: Simon Paulger <spaulger@codezen.co.uk>
+Uploaders: Simon Paulger <spaulger@codezen.co.uk>
 Build-Depends: apache2-dev (>= 2.4),
                autoconf (>= 2.63),
                automake,

--- a/assets/source/7.3/php-module.control.in
+++ b/assets/source/7.3/php-module.control.in
@@ -1,10 +1,9 @@
 Package: @package@
 Architecture: any
-Depends: php-common (>= 1:81~),
-         ucf,
+Depends: ucf,
          ${misc:Depends},
          ${php:Depends},
-	 ${php-@ext@:Depends},
+	     ${php-@ext@:Depends},
          ${shlibs:Depends}
 Pre-Depends: ${misc:Pre-Depends},
 	     ${php-@ext@:Pre-Depends}

--- a/assets/source/7.4/control.in
+++ b/assets/source/7.4/control.in
@@ -1,9 +1,8 @@
 Source: php@PHP_VERSION@
 Section: php
 Priority: optional
-Maintainer: Debian PHP Maintainers <team+pkg-php@tracker.debian.org>
-Uploaders: Ondřej Surý <ondrej@debian.org>,
-           Lior Kaplan <kaplan@debian.org>
+Maintainer: Simon Paulger <spaulger@codezen.co.uk>
+Uploaders: Simon Paulger <spaulger@codezen.co.uk>
 Build-Depends: apache2-dev (>= 2.4),
                autoconf (>= 2.63),
                automake,

--- a/assets/source/7.4/php-module.control.in
+++ b/assets/source/7.4/php-module.control.in
@@ -1,10 +1,9 @@
 Package: @package@
 Architecture: any
-Depends: php-common (>= 1:81~),
-         ucf,
+Depends: ucf,
          ${misc:Depends},
          ${php:Depends},
-	 ${php-@ext@:Depends},
+	     ${php-@ext@:Depends},
          ${shlibs:Depends}
 Pre-Depends: ${misc:Pre-Depends},
 	     ${php-@ext@:Pre-Depends}

--- a/assets/source/8.0/control.in
+++ b/assets/source/8.0/control.in
@@ -1,9 +1,8 @@
 Source: php@PHP_VERSION@
 Section: php
 Priority: optional
-Maintainer: Debian PHP Maintainers <team+pkg-php@tracker.debian.org>
-Uploaders: Ondřej Surý <ondrej@debian.org>,
-           Lior Kaplan <kaplan@debian.org>
+Maintainer: Simon Paulger <spaulger@codezen.co.uk>
+Uploaders: Simon Paulger <spaulger@codezen.co.uk>
 Build-Depends: apache2-dev (>= 2.4),
                autoconf (>= 2.63),
                automake,

--- a/assets/source/8.0/php-module.control.in
+++ b/assets/source/8.0/php-module.control.in
@@ -1,10 +1,9 @@
 Package: @package@
 Architecture: any
-Depends: php-common (>= 1:81~),
-         ucf,
+Depends: ucf,
          ${misc:Depends},
          ${php:Depends},
-	 ${php-@ext@:Depends},
+	     ${php-@ext@:Depends},
          ${shlibs:Depends}
 Pre-Depends: ${misc:Pre-Depends},
 	     ${php-@ext@:Pre-Depends}

--- a/assets/source/8.1/control.in
+++ b/assets/source/8.1/control.in
@@ -1,9 +1,8 @@
 Source: php@PHP_VERSION@
 Section: php
 Priority: optional
-Maintainer: Debian PHP Maintainers <team+pkg-php@tracker.debian.org>
-Uploaders: Ondřej Surý <ondrej@debian.org>,
-           Lior Kaplan <kaplan@debian.org>
+Maintainer: Simon Paulger <spaulger@codezen.co.uk>
+Uploaders: Simon Paulger <spaulger@codezen.co.uk>
 Build-Depends: apache2-dev (>= 2.4),
                autoconf (>= 2.63),
                automake,

--- a/assets/source/8.1/php-module.control.in
+++ b/assets/source/8.1/php-module.control.in
@@ -1,10 +1,9 @@
 Package: @package@
 Architecture: any
-Depends: php-common (>= 1:81~),
-         ucf,
+Depends: ucf,
          ${misc:Depends},
          ${php:Depends},
-	 ${php-@ext@:Depends},
+	     ${php-@ext@:Depends},
          ${shlibs:Depends}
 Pre-Depends: ${misc:Pre-Depends},
 	     ${php-@ext@:Pre-Depends}

--- a/assets/source/8.2/control.in
+++ b/assets/source/8.2/control.in
@@ -1,9 +1,8 @@
 Source: php@PHP_VERSION@
 Section: php
 Priority: optional
-Maintainer: Debian PHP Maintainers <team+pkg-php@tracker.debian.org>
-Uploaders: Ondřej Surý <ondrej@debian.org>,
-           Lior Kaplan <kaplan@debian.org>
+Maintainer: Simon Paulger <spaulger@codezen.co.uk>
+Uploaders: Simon Paulger <spaulger@codezen.co.uk>
 Build-Depends: apache2-dev (>= 2.4),
                autoconf (>= 2.63),
                automake,

--- a/assets/source/8.2/php-module.control.in
+++ b/assets/source/8.2/php-module.control.in
@@ -1,10 +1,9 @@
 Package: @package@
 Architecture: any
-Depends: php-common (>= 1:81~),
-         ucf,
+Depends: ucf,
          ${misc:Depends},
          ${php:Depends},
-	 ${php-@ext@:Depends},
+	     ${php-@ext@:Depends},
          ${shlibs:Depends}
 Pre-Depends: ${misc:Pre-Depends},
 	     ${php-@ext@:Pre-Depends}

--- a/assets/source/8.3/control.in
+++ b/assets/source/8.3/control.in
@@ -1,9 +1,8 @@
 Source: php@PHP_VERSION@
 Section: php
 Priority: optional
-Maintainer: Debian PHP Maintainers <team+pkg-php@tracker.debian.org>
-Uploaders: Ondřej Surý <ondrej@debian.org>,
-           Lior Kaplan <kaplan@debian.org>
+Maintainer: Simon Paulger <spaulger@codezen.co.uk>
+Uploaders: Simon Paulger <spaulger@codezen.co.uk>
 Build-Depends: apache2-dev (>= 2.4),
                autoconf (>= 2.63),
                automake,

--- a/assets/source/8.3/php-module.control.in
+++ b/assets/source/8.3/php-module.control.in
@@ -1,10 +1,9 @@
 Package: @package@
 Architecture: any
-Depends: php-common (>= 1:81~),
-         ucf,
+Depends: ucf,
          ${misc:Depends},
          ${php:Depends},
-	 ${php-@ext@:Depends},
+	     ${php-@ext@:Depends},
          ${shlibs:Depends}
 Pre-Depends: ${misc:Pre-Depends},
 	     ${php-@ext@:Pre-Depends}


### PR DESCRIPTION
Remove dependency on php-common Debian package to v7 builds and change maintainer email address.